### PR TITLE
'webkit-playsinline' not works well in some ios

### DIFF
--- a/player.vue
+++ b/player.vue
@@ -132,7 +132,7 @@
 
         // 是否应用IOS下的禁止自动全屏
         var playsinline = options.playsinline
-        playsinline && this.$el.children[0].setAttribute('webkit-playsinline', playsinline)
+        playsinline && (this.$el.children[0].setAttribute('playsinline', playsinline),this.$el.children[0].setAttribute('webkit-playsinline', playsinline))
 
         // 是否适用youtube
         // if (video_options.techOrder.indexOf('youtube') > -1) require('videojs-youtube')


### PR DESCRIPTION
My test device is iphone6,IOS10+. The 'webkit-playsinline' doesn't work on any browsers(Safari,chrome or some app webview).At the mean while, the 'playsinline' is totally suppoted and works well. So,I add the 'playsinline' when the option.playsinline is true. In case of some special needs,still keeping the 'webkit-playsinline'.