### PR TITLE
加载视频后报错

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
  * Adapted from Videojs (https://github.com/videojs/video.js)
  *
  */
-
+window.WebVTT = require('videojs-vtt.js').WebVTT
 window.videojs = require('video.js')
 require('video.js/dist/alt/video-js-cdn.css')
 videojs.options.flash.swf = "https://cdn.bootcss.com/video.js/5.13.0/video-js.swf"


### PR DESCRIPTION
![default](https://cloud.githubusercontent.com/assets/5174886/22199850/9c9f720e-e197-11e6-9267-ae1f86f29f16.png)
从video.js的issue中找到的解决办法
参考：[https://github.com/videojs/video.js/issues/2135](url)