### PR TITLE
avoid error "VIDEOJS: ERROR: Unable to find plugin: __ob__"

### DIFF
--- a/player.vue
+++ b/player.vue
@@ -61,7 +61,8 @@
             }
           },
           techOrder: ['html5', 'flash'],
-          playbackRates: []
+          playbackRates: [],
+          plugins:{}
         }, this.options)
 
         // check sources
@@ -98,6 +99,8 @@
         // videoOptions
         // console.log(videoOptions)
 
+        // avoid error "VIDEOJS: ERROR: Unable to find plugin: __ob__"
+        delete videoOptions.plugins.__ob__;
         this.player = videojs(this.$el.children[0], videoOptions, function() {
 
           // player readied


### PR DESCRIPTION
avoid error "VIDEOJS: ERROR: Unable to find plugin: __ob__"
options.plugins 参数从vue传入时会加上 __ob__，videojs以为是个插件，尝试加载该插件失败会报错