### PR TITLE
Add error event to event emitters

### DIFF
--- a/src/player.vue
+++ b/src/player.vue
@@ -123,7 +123,8 @@
                         'pause', 
                         'waiting', 
                         'playing', 
-                        'ended']
+                        'ended',
+                        'error']
           for (var i = 0; i < events.length; i++) {
             (function(event) {
               _this.on(event, function() {


### PR DESCRIPTION
Wasn't able to catch error events from the player - so I added the event to the array of events that should emit from the component.