### PR TITLE
videojs-contrib-hls deprecated (#205)

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,11 +228,6 @@ videojs.addLanguage('es', {
 ```
 
 
-# Issues
-
-[videojs-contrib-hls - e is not defined](https://github.com/surmon-china/vue-video-player/issues/90)
-
-
 # API
 - component api:
   * `events` : `[ Array, default: [] ]` : custom videojs event to component
@@ -248,7 +243,6 @@ videojs.addLanguage('es', {
 # videojs plugins
 
 - [videojs-resolution-switcher](https://github.com/kmoskwiak/videojs-resolution-switcher)
-- [videojs-contrib-hls](https://github.com/videojs/videojs-contrib-hls)
 - [videojs-youtube](https://github.com/videojs/videojs-youtube)
 - [videojs-vimeo](https://github.com/videojs/videojs-vimeo)
 - [videojs-hotkeys](https://github.com/ctd1500/videojs-hotkeys)

--- a/package.json
+++ b/package.json
@@ -48,8 +48,7 @@
   },
   "dependencies": {
     "object-assign": "^4.1.1",
-    "video.js": "^6.6.0",
-    "videojs-contrib-hls": "^5.12.2",
+    "video.js": "^7.2.0",
     "videojs-flash": "^2.1.0",
     "videojs-hotkeys": "^0.2.20"
   },


### PR DESCRIPTION
upgraded videojs version + removed instances of videojs-contrib-hls