### PR TITLE
解决安卓微信点击播放自动全屏 BUG

### DIFF
--- a/src/player.vue
+++ b/src/player.vue
@@ -135,7 +135,7 @@
           this.$refs.video.setAttribute('playsinline', this.playsinline)
           this.$refs.video.setAttribute('webkit-playsinline', this.playsinline)
           this.$refs.video.setAttribute('x5-playsinline', this.playsinline)
-          this.$refs.video.setAttribute('x5-video-player-type', 'h5')
+          this.$refs.video.setAttribute('x5-video-player-type', 'h5-page')
           this.$refs.video.setAttribute('x5-video-player-fullscreen', false)
         }
 


### PR DESCRIPTION
经过三部华为手机真机测试，发现 x5-video-player-type="h5" 还是会全屏播放，改为 h5-page 就正常了